### PR TITLE
Support for \include, more elaborate example, removal of .aux and .log

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -50,7 +50,7 @@ BIBFILES = $(patsubst %,%.bib,\
 ## re-typesetting.
 INCLUDEDTEX = $(patsubst %,%.tex,\
 		$(shell grep '^[^%]*\\\(input\|include\){' $(TARGET).tex | \
-			sed 's/[^{]*{\([^}]*\)}/\1/'))
+			sed 's/[^{]*{\([^}]*\)}.*/\1/'))
 
 ## grab a version number from the repository (if any) that stores this.
 ## * REVISION is the current revision number (short form, for inclusion in text)
@@ -121,8 +121,12 @@ endif
 	@while grep -q "Rerun to" $*.log; do \
 		$(PDFLATEX) $*; done
 
+# remove .aux and .log files created by files in $(INCLUDEDTEX)
+AUXFILES = $(patsubst %.tex,%.aux, $(INCLUDEDTEX))
+LOGFILES = $(patsubst %.tex,%.log, $(INCLUDEDTEX))
+
 clean:
 	$(RM) $(TARGET).aux $(TARGET).log $(TARGET).out \
 		$(TARGET).pdf $(TARGET).blg $(TARGET).bbl \
 		$(TARGET).lof $(TARGET).lot $(TARGET).toc \
-		$(REVDEPS)
+		$(REVDEPS) $(AUXFILES) $(LOGFILES)

--- a/example/canoe.tex
+++ b/example/canoe.tex
@@ -1,0 +1,6 @@
+\section{How to build a canoe from two twigs and a roll of yarn}
+\label{sec:build-canoe}
+
+First, select two twigs of a suitable length. Next, please refer to section \ref{sec:write-me}.
+
+This file serves to exemplify the removal of \texttt{.aux} and \texttt{.log} files.

--- a/example/example.tex
+++ b/example/example.tex
@@ -5,7 +5,10 @@
 \input{abstract} % this comment will be ignored
 
 % \input{introduction}
+\include{canoe}
 
+\section{Write me}
+\label{sec:write-me}
 Write me.~\cite{www:pdflatex-makefile}
 
 \bibliographystyle{abbrv}


### PR DESCRIPTION
The makefile now also supports .tex files included with `\include`. Extended the example to include a reference (to generate .aux and .log files). Added functionality to remove these files when invoking "clean".
