### PR TITLE
Small makefile improvements

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -27,7 +27,7 @@ OS=$(shell uname -s)
 ifeq ($(OS),Darwin)
 PDFVIEWER	?= open -a Preview
 else
-PDFVIEWER	?= evince
+PDFVIEWER	?= xdg-open
 endif
 
 ## Name of the target file, minus .pdf: e.g., TARGET=mypaper causes this


### PR DESCRIPTION
The first accounts for the fact that the existence of `.git/$(GIT_BRANCH)` is not guaranteed (try a `git gc` for example), so switches the dep to `.git/HEAD` which I've used in other similar situations.

The second will use the user's preferred pdf viewer, rather than hardcoded evince, to open the file. (As a side effect, it doesn't block the terminal - it launches in the background)
