### PR TITLE
Remove .nav and .snm on make clean

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -125,5 +125,6 @@ LOGFILES = $(TARGET).log $(patsubst %.tex,%.log, $(INCLUDEDTEX))
 clean:
 	$(RM) $(foreach T,$(PDFTARGETS:.pdf=), \
 		$(T).out $(T).pdf $(T).blg $(T).bbl \
-		$(T).lof $(T).lot $(T).toc $(T).idx) \
+		$(T).lof $(T).lot $(T).toc $(T).idx \
+		$(T).nav $(T).snm) \
 		$(REVDEPS) $(AUXFILES) $(LOGFILES)


### PR DESCRIPTION
The beamer class writes .nav and .snm files. These should be cleaned up.
