### PR TITLE
avoid echoing extra \ on non-Mac platforms

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -98,7 +98,7 @@ revision.tex: $(VCSTURD)
   ifeq ($(OS),Darwin)
 	echo "\\\\newcommand{\\\\Revision}{$(REVISION)}" > $@
   else
-	echo "\\\newcommand{\\Revision}{$(REVISION)}" > $@
+	echo "\\newcommand{\\Revision}{$(REVISION)}" > $@
   endif
 endif
 


### PR DESCRIPTION
This extra \ (which I think was a typo) was causing the revision.tex file to contain "\newcommand..." on my Linux box.
