### PR TITLE
Improve quiet mode (make it quieter)

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -22,7 +22,7 @@
 PDFLATEX	?= pdflatex -halt-on-error -file-line-error
 ifneq ($(QUIET),)
 PDFLATEX	+= -interaction=batchmode
-ERRFILTER	:= > /dev/null || (egrep ':[[:digit:]+]:' *.log && false)
+ERRFILTER	:= > /dev/null || (egrep ':[[:digit:]]+:' *.log && false)
 else
 PDFLATEX	+= -interaction=nonstopmode
 ERRFILTER=


### PR DESCRIPTION
Here are a few changes/fixes that make QUIET=1 mode less noisy (except for actual errors, which weren't being printed before).
