### PR TITLE
Don't remove final products in 'clean'

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -91,7 +91,7 @@ else ifneq ($(wildcard .svn/entries),)
 endif
 
 # .PHONY names all targets that aren't filenames
-.PHONY: all clean pdf view snapshot distill
+.PHONY: all clean pdf view snapshot distill distclean
 
 all: pdf $(AFTERALL)
 
@@ -144,10 +144,14 @@ snapshot: $(DRAFTS)
 
 distill: $(PDFTARGETS:.pdf=.distilled.pdf)
 
+distclean: clean
+	$(RM) $(PDFTARGETS) $(PDFTARGETS:.pdf=.distilled.pdf) $(EXTRADISTCLEAN)
+
 clean:
 	$(RM) $(foreach T,$(TARGETS), \
-		$(T).out $(T).pdf $(T).blg $(T).bbl \
+		$(T).out $(T).blg $(T).bbl \
 		$(T).lof $(T).lot $(T).toc $(T).idx \
-		$(T).nav $(T).snm $(T).distilled.pdf) \
+		$(T).nav $(T).snm) \
 		$(REVDEPS) $(AUXFILES) $(LOGFILES) \
 		$(EXTRACLEAN)
+


### PR DESCRIPTION
Fairly often, I want to remove all the temporary files generated by a LaTeX run, but I want to keep the final product---just like I want to remove all the intermediate object files but not the main binary when I compile a C program. This splits the removal of the PDF targets (and the "distilled" versions) into a separate "distclean" target.
