### PR TITLE
Avoid problem with colons in output of svnversion.

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -86,7 +86,7 @@ else ifeq ($(shell hg root >/dev/null 2>&1 && echo USING_HG),USING_HG)
   VCSTURD := $(subst $(SPACE),\ ,$(shell hg root)/.hg/dirstate)
 else ifneq ($(wildcard .svn/entries),)
   # subversion
-  REVISION := $(shell svnversion -n)
+  REVISION := $(subst :,-,$(shell svnversion -n))
   VCSTURD := .svn/entries
 endif
 


### PR DESCRIPTION
`svnversion' output can contain colons. If this happens, then the following Makefile line is misparsed by GNU Make:

$(DRAFTS): %-$(REVISION).pdf: %.pdf

The error is: "Makefile.include:136: **\* target pattern contains no `%'.  Stop."

Avoid this error by replacing colons in the output of `svnversion' with dashes.
