### PR TITLE
Fix git-dir when the repository is a submodule.

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -73,12 +73,12 @@ ifeq ($(shell git status >/dev/null 2>&1 && echo USING_GIT),USING_GIT)
   ifeq ($(shell git svn info >/dev/null 2>&1 && echo USING_GIT_SVN),USING_GIT_SVN)
     # git-svn
     REVISION := $(shell git svn find-rev git-svn)
-    VCSTURD := $(subst $(SPACE),\ ,$(shell git rev-parse --show-toplevel)/.git/refs/remotes/git-svn)
+    VCSTURD := $(subst $(SPACE),\ ,$(shell git rev-parse --git-dir)/refs/remotes/git-svn)
   else
     # plain git
     REVISION := $(shell git rev-parse --short HEAD)
     GIT_BRANCH := $(shell git symbolic-ref HEAD 2>/dev/null)
-    VCSTURD := $(subst $(SPACE),\ ,$(shell git rev-parse --show-toplevel)/.git/$(GIT_BRANCH))
+    VCSTURD := $(subst $(SPACE),\ ,$(shell git rev-parse --git-dir)/$(GIT_BRANCH))
   endif
 else ifeq ($(shell hg root >/dev/null 2>&1 && echo USING_HG),USING_HG)
   # mercurial


### PR DESCRIPTION
When the repository is a git submodule, (...)/.git is not a directory and
the VCSTURD file was not found by make.

```
git rev-parse --git-dir
```

handles submodules correctly and fixes the issue.
