### PR TITLE
clean up file created by the dagstuhl LIPIcs template

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -151,7 +151,7 @@ clean:
 	$(RM) $(foreach T,$(TARGETS), \
 		$(T).out $(T).blg $(T).bbl \
 		$(T).lof $(T).lot $(T).toc $(T).idx \
-		$(T).nav $(T).snm) \
+		$(T).nav $(T).snm $(T).vtc) \
 		$(REVDEPS) $(AUXFILES) $(LOGFILES) \
 		$(EXTRACLEAN)
 


### PR DESCRIPTION
...which SNAPL is using
