### PR TITLE
Updated GitHub URL in curl command of the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 If your main file is `mypaper.tex`:
 
-    $ curl -O https://raw.github.com/ransford/pdflatex-makefile/master/Makefile.include
+    $ curl -O https://raw.githubusercontent.com/ransford/pdflatex-makefile/master/Makefile.include
     $ cat > Makefile
     TARGET=mypaper
     include Makefile.include


### PR DESCRIPTION
Updated the URL since the old URL is not valid any more and therefore curl does not download the Makefile.include file.