### PR TITLE
Generate more descriptive git revisions

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -109,7 +109,7 @@ view: $(PDFTARGETS)
 ifneq ($(REVISION),)
 REVDEPS += revision.tex
 revision.tex: $(VCSTURD)
-	/bin/echo '\newcommand{\Revision}'"{$(REVISION)}" > $@
+	/bin/echo '\newcommand{\Revision}'"{$(subst _,\_,$(REVISION))}" > $@
 AUXFILES += revision.aux
 endif
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -78,7 +78,7 @@ ifeq ($(shell git status >/dev/null 2>&1 && echo USING_GIT),USING_GIT)
     VCSTURD := $(subst $(SPACE),\ ,$(shell git rev-parse --git-dir)/refs/remotes/git-svn)
   else
     # plain git
-    REVISION := $(shell git rev-parse --short HEAD)
+    REVISION := $(shell git describe --always HEAD)
     GIT_BRANCH := $(shell git symbolic-ref HEAD 2>/dev/null)
     VCSTURD := $(subst $(SPACE),\ ,$(shell git rev-parse --git-dir)/$(GIT_BRANCH))
   endif


### PR DESCRIPTION
I've found that `git describe` generates more descriptive revision.
It will generate revisions in the format of `<last tag>-<number of commits since last tag>-g<short commit SHA>` (e.g. `script_v14-9-g3b847fd`).
With the `--always` option it will fall back to a unique short commit SHA.
(see docs: https://www.git-scm.com/docs/git-describe)

PS: I've made it escape `_` in the output since LaTeX doesn't like them unescaped.