### PR TITLE
Allows definition of custom Bibfiles.

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -56,7 +56,7 @@ LOGFILES   = $(TARGETS:=.log)
 ## $(BIBFILES) will contain foo.bib and bar.bib, and both files will be added as
 ## dependencies to $(PDFTARGETS).
 ## Effect: updating a .bib file will trigger re-typesetting.
-BIBFILES = $(patsubst %,%.bib,\
+BIBFILES += $(patsubst %,%.bib,\
 		$(shell grep '^[^%]*\\bibliography{' $(TEXTARGETS) | \
 			grep -o '\\bibliography{[^}]\+}' | \
 			sed -e 's/^[^%]*\\bibliography{\([^}]*\)}.*/\1/' \


### PR DESCRIPTION
If the Bibfiles are included without the "\bibliography" command
directly, they won't get detected. This small change lets the user
define custom Bibfiles in the root Makefile.