### PR TITLE
First version working with biber+biblatex

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -118,7 +118,7 @@ else ifneq ($(wildcard .svn/entries),)
 endif
 
 # .PHONY names all targets that aren't filenames
-.PHONY: all clean pdf view snapshot distill distclean
+.PHONY: all clean pdf view snapshot distill distclean checkbib
 
 all: pdf $(AFTERALL)
 
@@ -196,3 +196,6 @@ clean:
 		$(T).vtc $(T).url) \
 		$(REVDEPS) $(AUXFILES) $(LOGFILES) \
 		$(EXTRACLEAN)
+
+checkbib:
+	echo "$(BIBTEX) $(BIBFILES) $(BIBLATEX)"

--- a/Makefile.include
+++ b/Makefile.include
@@ -56,7 +56,7 @@ LOGFILES   = $(TARGETS:=.log)
 ## $(BIBFILES) will contain foo.bib and bar.bib, and both files will be added as
 ## dependencies to $(PDFTARGETS).
 ## Effect: updating a .bib file will trigger re-typesetting.
-BIBLATEX = $(shell grep "^[^%]*\\\\usepackage\\(\\[[^\\]]\\]\\){biblatex}" $(TEXTARGETS))
+BIBLATEX = $(shell grep "^[^%]*\\\\usepackage\\(\\[.*\\]\\){biblatex}" $(TEXTARGETS))
 ifneq ($(BIBLATEX),)
   BIBINCLUDE = addbibresource
   BACKEND = $(shell grep -o 'backend=\([A-Za-z0-9]\+\)' $(TEXTARGETS) | sed -e 's/^.*=//')

--- a/Makefile.include
+++ b/Makefile.include
@@ -68,11 +68,16 @@ ifneq ($(BIBLATEX),)
 else
   BIBINCLUDE = bibliography
 endif
-BIBFILES += $(patsubst %,%.bib,\
-		$(shell grep "^[^%]*\\\\$(BIBINCLUDE){" $(TEXTARGETS) | \
+BIBSTEM += $(shell grep "^[^%]*\\\\$(BIBINCLUDE){" $(TEXTARGETS) | \
 			grep -o "\\\\$(BIBINCLUDE){[^}]\\+}" | \
 			sed -e "s/^[^%]*\\\\$(BIBINCLUDE){\\([^}]*\\)}.*/\\1/" \
-			    -e 's/, */ /g'))
+			    -e 's/, */ /g')
+
+ifneq ($(BIBLATEX),)
+  BIBFILES += $(BIBSTEM)
+else
+  BIBFILES += $(patsubst %,%.bib, $(BIBSTEM))
+endif
 
 ## Add \input'ed or \include'd files to $(PDFTARGETS) dependencies; ignore
 ## .tex extensions.


### PR DESCRIPTION
There are still a few issues.
1. I have no idea how regexps actually function, so I just randomly tried to find something which recognizes the usage of  `\usepackage[<options>]{biblatex}`. Your version did not do so correctly.
2. There is a `checkbib` phony target giving the actual content of `$BIBTEX`,`$BIBFILES` and `$BIBLATEX`—you may use this to check your regexps or to optimize my grepping.
3. The optional arguments of biblatex are typically split by linebreaks, since they are so numerous. The Makefile does **not** allow this, yet.
4. For some mysterious reason the arguments of `\bibliography` and `\addbibressource` typically differ by a `.bib`. I have added some case distinctions to take care of that. However, it is not particularly _pretty_, I must confess.
5. Some deeply arcane effect of the stars invokes `bibtex` after all the compilation (including execution of biber) finishes correctly—resulting in `make` returning an error code. Have no clue whether this is a _feature_ of `make` or some hidden `Makefile.include` magic.
