### PR TITLE
From svn1.7 only the root dir contains a .svn dir

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -97,12 +97,12 @@ else ifeq ($(shell hg root >/dev/null 2>&1 && echo USING_HG),USING_HG)
     REVISION := $(shell hg id -i)
   endif
   VCSTURD := $(subst $(SPACE),\ ,$(shell hg root)/.hg/dirstate)
-else ifneq ($(wildcard .svn/entries),)
+else ifeq ($(shell svn info >/dev/null && echo USING_SVN),USING_SVN)
   # subversion
   ifeq ($(REVISION),)
     REVISION := $(subst :,-,$(shell svnversion -n))
   endif
-  VCSTURD := .svn/entries
+  VCSTRUD := $(addsuffix /.svn/entries, $(shell svn info | grep 'Root Path' | sed -e 's/\(.*\:\)\(.*\) /\2/'))
 endif
 
 # .PHONY names all targets that aren't filenames

--- a/Makefile.include
+++ b/Makefile.include
@@ -102,7 +102,7 @@ else ifeq ($(shell svn info >/dev/null && echo USING_SVN),USING_SVN)
   ifeq ($(REVISION),)
     REVISION := $(subst :,-,$(shell svnversion -n))
   endif
-  VCSTRUD := $(addsuffix /.svn/entries, $(shell svn info | grep 'Root Path' | sed -e 's/\(.*\:\)\(.*\) /\2/'))
+  VCSTURD := $(addsuffix /.svn/entries, $(shell svn info | grep 'Root Path' | sed -e 's/\(.*\:\)\(.*\) /\2/'))
 endif
 
 # .PHONY names all targets that aren't filenames


### PR DESCRIPTION
Prevent that the file .svn/entries cannot be found when using svn > 1.7.
["Subversion 1.7 working copies have just one .svn directory—in the root of the working copy."][ref]

[ref]:http://subversion.apache.org/docs/release-notes/1.7.html#wc-ng