### PR TITLE
Clean up .fdb_latexmk and .fls files

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -208,8 +208,9 @@ distclean: clean
 clean:
 	$(RM) $(foreach T,$(TARGETS), \
 		$(T).bbl $(T).bcf $(T).bit $(T).blg \
-		$(T)-blx.bib $(T).brf $(T).glg $(T).glo \
-		$(T).gls $(T).glsdefs $(T).glx \ $(T).gxg \
+		$(T)-blx.bib $(T).brf $(T).fdb_latexmk \
+		$(T).fls $(T).glg $(T).glo $(T).gls \
+		$(T).glsdefs $(T).glx \ $(T).gxg \
 		$(T).gxs $(T).idx $(T).ilg $(T).ind \
 		$(T).ist $(T).loa $(T).lof $(T).lol \
 		$(T).lot $(T).maf $(T).mtc $(T).nav \


### PR DESCRIPTION
I found that `make clean` was leaving around `.fdb_latexmk` and `.fls` files.  This PR will remove these files when `make clean` is run.

Also, I'm curious why the `.pdf` file itself is not removed as part of the `make clean` process? (since it's an artifact of the build)