### PR TITLE
Add support for Biblatex/Biber

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -25,16 +25,18 @@
 
 PDFLATEX	?= pdflatex -halt-on-error -file-line-error -shell-escape
 BIBTEX		?= bibtex
+BIBER		?= biber
 MAKEGLOSSARIES ?= makeglossaries
 MAKENOMENCL ?= makeindex
 
 ## String to find in log to check whether rerun is necessary
-RERUN_PATTERN = Rerun to
+RERUN_PATTERN = Rerun to|rerun LaTeX|run LaTeX again
 
 ifneq ($(QUIET),)
 PDFLATEX	+= -interaction=batchmode
 ERRFILTER	:= > /dev/null || (egrep ':[[:digit:]]+:' *.log && false)
 BIBTEX		+= -terse
+BIBER		+= --quiet
 else
 PDFLATEX	+= -interaction=nonstopmode
 ERRFILTER=
@@ -65,14 +67,23 @@ else
 endif
 
 ## If $(TARGET).tex refers to .bib files like \bibliography{foo,bar}, then
-## $(BIBFILES) will contain foo.bib and bar.bib, and both files will be added as
+## $(BIBTEXFILES) will contain foo.bib and bar.bib, and both files will be added as
 ## dependencies to $(PDFTARGETS).
 ## Effect: updating a .bib file will trigger re-typesetting.
-BIBFILES += $(patsubst %,%.bib,\
+BIBTEXFILES += $(patsubst %,%.bib,\
 		$(shell grep '^[^%]*\\bibliography{' $(TEXTARGETS) | \
 			grep -o '\\bibliography{[^}]\+}' | \
 			sed -e 's/^[^%]*\\bibliography{\([^}]*\)}.*/\1/' \
 			    -e 's/, */ /g'))
+
+## If $(TARGET).tex refers to .bib files like \addbibresource{foo.bib}, then
+## $(BIBLATEXFILES) will contain foo.bib and  will be added as dependencies to $(PDFTARGETS).
+## Effect: updating a .bib file will trigger re-typesetting.
+BIBLATEXFILES += $(shell \
+			grep '^[^%]*\\addbibresource{' $(TEXTARGETS) | \
+			grep -o '\\addbibresource{[^}]\+}' | \
+			sed -e 's/^[^%]*\\addbibresource{\([^}]*\)}.*/\1/' \
+			    -e 's/, */ /g')
 
 ## Add \input'ed or \include'd files to $(PDFTARGETS) dependencies; ignore
 ## .tex extensions.
@@ -145,7 +156,7 @@ AUXFILES += revision.aux
 endif
 
 # to generate aux but not pdf from pdflatex, use -draftmode
-%.aux: %.tex $(REVDEPS)
+%.aux %.bcf: %.tex $(REVDEPS)
 	$(PDFLATEX) -draftmode $* $(ERRFILTER)
 
 # specify KEEPAUX=1 if you need to keep auxiliary (.aux) files for some other
@@ -155,10 +166,17 @@ ifneq ($(KEEPAUX),1)
 endif
 
 # introduce BibTeX dependency if we found a \bibliography
-ifneq ($(strip $(BIBFILES)),)
+ifneq ($(strip $(BIBTEXFILES)),)
 BIBDEPS = %.bbl
-%.bbl: %.aux $(BIBFILES)
+%.bbl: %.aux $(BIBTEXFILES)
 	$(BIBTEX) $*
+endif
+
+# introduce BibLaTeX/Biber dependency if we found a \addbibresource
+ifneq ($(strip $(BIBLATEXFILES)),)
+BIBDEPS = %.bbl
+%.bbl: %.aux %.bcf $(BIBLATEXFILES)
+	$(BIBER) $*
 endif
 
 # introduce makeglossaries dependency if we found \printglossary/ies
@@ -183,11 +201,15 @@ endif
 
 $(PDFTARGETS): %.pdf: %.tex %.aux $(GLSDEPS) $(BIBDEPS) $(INCLUDEDTEX) $(REVDEPS) $(NLSDEPS)
 	$(PDFLATEX) $* $(ERRFILTER)
-ifneq ($(strip $(BIBFILES)),)
+ifneq ($(strip $(BIBTEXFILES)),)
 	@if egrep -q "undefined (references|citations)" $*.log; then \
 		$(BIBTEX) $* && $(PDFLATEX) $* $(ERRFILTER); fi
 endif
-	@while grep -q "$(RERUN_PATTERN)" $*.log; do \
+ifneq ($(strip $(BIBLATEXFILES)),)
+	@if egrep -q "Please \(re\)run Biber on the file:" $*.log; then \
+		$(BIBER) $*; fi
+endif
+	@while egrep -q "$(RERUN_PATTERN)" $*.log; do \
 		$(PDFLATEX) $* $(ERRFILTER); done
 
 DRAFTS := $(PDFTARGETS:.pdf=-$(REVISION).pdf)

--- a/example/example.tex
+++ b/example/example.tex
@@ -14,6 +14,10 @@
 \documentclass{article}
 \usepackage{graphicx}
 
+% see examples of different styles e.g. on https://www.overleaf.com/learn/latex/Biblatex_bibliography_styles
+\usepackage[style=numeric,backref=true]{biblatex}
+\addbibresource{examplebib.bib}
+
 % Generate the glossary and define terms
 \usepackage{glossaries}
 \makeglossaries
@@ -45,9 +49,7 @@
 \label{sec:write-me}
 Write me.~\cite{www:pdflatex-makefile}
 
-\bibliographystyle{abbrv}
-\bibliography{examplebib} % this comment will be ignored
-% \bibliography{commented}
+\printbibliography[title=Sources] % this comment will be ignored
 
 \printglossaries
 

--- a/example/examplebib.bib
+++ b/example/examplebib.bib
@@ -1,4 +1,4 @@
-@misc{www:pdflatex-makefile,
+@online{www:pdflatex-makefile,
 	author = {Benjamin Ransford},
 	title = {pdflatex-makefile},
-	howpublished = {http://github.com/ransford/pdflatex-makefile}}
+	url = {http://github.com/ransford/pdflatex-makefile}}


### PR DESCRIPTION
This adds support for the more modern Biblatex/Biber backend. `.bib` files stay the same, but including them into a document changes a bit (see updated example).
It can be supported alongside the old Bibtex (note the missing "la" :neutral_face: ) backend since both use different commands.