### PR TITLE
Remove deprecated .setpdfwrite operator

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -221,7 +221,7 @@ snapshot: $(DRAFTS)
 
 %.distilled.pdf: %.pdf
 	gs -q -dSAFER -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile=$@ \
-		-dCompatibilityLevel=1.5 -dPDFSETTINGS=/prepress -c .setpdfwrite -f $<
+		-dCompatibilityLevel=1.5 -dPDFSETTINGS=/prepress $<
 	exiftool -overwrite_original -Title="" -Creator="" -CreatorTool="" $@
 
 distill: $(PDFTARGETS:.pdf=.distilled.pdf)


### PR DESCRIPTION
It looks like the `.setpdfwrite` operator is now deprecated and was causing errors for me when running `make distill`.

From https://www.ghostscript.com/doc/9.50/Language.htm):
> This operator is now deprecated, and its use is discouraged